### PR TITLE
Downgrade Drone CLI to use the deploy command

### DIFF
--- a/deployment/roles/rhobot/tasks/main.yml
+++ b/deployment/roles/rhobot/tasks/main.yml
@@ -61,7 +61,7 @@
 - name: Download Drone CLI client
   become: yes
   become_user: "{{ rhobot_user }}"
-  shell: curl --silent --show-error --location https://github.com/drone/drone-cli/releases/download/v1.0.7/drone_linux_amd64.tar.gz | tar zx
+  shell: curl --silent --show-error --location https://github.com/drone/drone-cli/releases/download/v0.8.6/drone_linux_amd64.tar.gz | tar zx
   args:
     chdir: "/home/{{ rhobot_user }}/.local/bin"
 

--- a/rhobot/rhobot.py
+++ b/rhobot/rhobot.py
@@ -16,10 +16,6 @@ from gidgethub import aiohttp as gh_aiohttp
 from gidgethub import sansio
 
 
-class MalformedDroneOutputError(ValueError):
-    pass
-
-
 class NoPreviousBuild(ValueError):
     pass
 
@@ -84,7 +80,7 @@ async def pushed_to_dev(logger_context: Logger) -> None:
     logger_context.info(perf_harness_output)
 
 
-def start_drone_build(contract_file_basename: str, commit_sha: str, repo_url: str) -> str:
+def start_drone_build(contract_file_basename: str, commit_sha: str, repo_url: str) -> int:
     drone_server = os.environ['PERF_HARNESS_DRONE_SERVER']
     drone_token = os.environ['PERF_HARNESS_DRONE_TOKEN']
 
@@ -98,12 +94,13 @@ def start_drone_build(contract_file_basename: str, commit_sha: str, repo_url: st
             '--param=CONTRACT=/workdir/rchain-perf-harness/{}'.format(contract_file_basename),
             '--param=RCHAIN_COMMIT_HASH={}'.format(commit_sha),
             '--param=RCHAIN_REPO={}'.format(repo_url),
+            '--format={{ .Number }}',
             'rchain/perf-harness',
             str(last_build_number),
             'custom_commit',
         ],
     )
-    return output.strip()
+    return int(output.strip())
 
 
 async def is_collaborator(github: gh_aiohttp.GitHubAPI, owner: str, repo: str, user: str) -> bool:
@@ -122,13 +119,10 @@ async def is_collaborator(github: gh_aiohttp.GitHubAPI, owner: str, repo: str, u
         return False
 
 
-def get_build_url_from_restart_output(output: str) -> str:
-    match = re.match('^Starting build (?P<repo>.*)#(?P<build>.*)', output)
-    if match is None:
-        raise MalformedDroneOutputError(output)
-    result = 'https://drone.perf.rchain-dev.tk/{repo}/{build}'.format(
-        repo=match.group('repo'),
-        build=match.group('build'),
+def make_build_url(repo: str, build_number: int) -> str:
+    result = 'https://drone.perf.rchain-dev.tk/{repo}/{build_number}'.format(
+        repo=repo,
+        build_number=build_number,
     )
     return result
 
@@ -145,10 +139,10 @@ async def rhobot_try(logger_context: Logger, event: sansio.Event, github: gh_aio
         logger_context.info('Ignoring a non-collaborator user: {}', user)
         return
 
-    output = start_drone_build(contract_file_basename, commit_sha, repo_url)
-    logger_context.info(output)
+    build_number = start_drone_build(contract_file_basename, commit_sha, repo_url)
+    logger_context.info(build_number)
 
-    build_url = get_build_url_from_restart_output(output)
+    build_url = make_build_url('rchain/perf-harness', build_number)
     comments_url = event.data['issue']['comments_url']
     await github.post(comments_url, data={'body': build_url})
 


### PR DESCRIPTION
The 1.x versions do not have the 'deploy' command, which we use in
.drone.yml